### PR TITLE
Update to ArgoCD v2.0.0

### DIFF
--- a/clusters/k3s/argocd/argocd.yaml
+++ b/clusters/k3s/argocd/argocd.yaml
@@ -11,7 +11,7 @@ spec:
   chart:
     spec:
       chart: argo-cd
-      version: "2.17.4"
+      version: "3.0.0"
       sourceRef:
         kind: HelmRepository
         name: argo
@@ -23,7 +23,7 @@ spec:
     global:
       image:
         repository: quay.io/argoproj/argocd
-        tag: v1.8.7
+        tag: v2.0.0
 
     controller:
       enableStatefulSet: true


### PR DESCRIPTION
v2.0.0 was released today: https://github.com/argoproj/argo-cd/releases/tag/v2.0.0
Also a new chart was release a few hours ago: https://github.com/argoproj/argo-helm/pull/645