### PR TITLE
Test if PR 72 works as expected

### DIFF
--- a/clusters/k3s/storage/nfs-data.yaml
+++ b/clusters/k3s/storage/nfs-data.yaml
@@ -9,10 +9,10 @@ spec:
   chart:
     spec:
       chart: nfs-subdir-external-provisioner
-      version: "4.0.7"
+      version: "4.0.8-0"
       sourceRef:
         kind: HelmRepository
-        name: nfs-subdir-provisioner
+        name: chartmuseum-local-charts
         namespace: flux-system
       interval: 1m
   values:
@@ -24,3 +24,7 @@ spec:
       defaultClass: true
       name: "nfs-data"
       provisionerName: cluster.local/nfs-data-provisioner
+    labels:
+      kubernetes.kilchhofer.info/foo: foo-label
+      kubernetes.kilchhofer.info/bar: bar-label
+      kubernetes.kilchhofer.info/baz: baz-label


### PR DESCRIPTION
This change test if upstream PR (https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/pull/72) works as expected